### PR TITLE
 Support passwords containing restricted characters

### DIFF
--- a/config/keys.js
+++ b/config/keys.js
@@ -1,3 +1,5 @@
+dbPassword = 'mongodb+srv://YOUR_USERNAME_HERE:'+ encodeURIComponent('YOUR_PASSWORD_HERE') + '@CLUSTER_NAME_HERE.mongodb.net/test?retryWrites=true';
+
 module.exports = {
-  mongoURI: 'ADD_MONGO_URI_HERE'
+    mongoURI: dbPassword
 };


### PR DESCRIPTION
MongoDB doesn't allow passwords containing special characters (@, /, !) unless they're been URLEncoded, that is why I started this pull request